### PR TITLE
delete the previous launching image

### DIFF
--- a/fun-facts-splashscreens-runcommand-onend.sh
+++ b/fun-facts-splashscreens-runcommand-onend.sh
@@ -5,7 +5,8 @@ readonly RP_CONFIG_DIR="/opt/retropie/configs"
 readonly SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 readonly SYSTEM="$1"
 readonly ROM_PATH="$3"
+readonly LAUNCHING="$RP_CONFIG_DIR/$SYSTEM/launching"
 
-[[ -f "$RP_CONFIG_DIR/$SYSTEM/launching.png"  ]] && rm "$RP_CONFIG_DIR/$SYSTEM/launching.png"
+rm -f "$LAUNCHING.png" "$LAUNCHING.jpg"
 
 sudo "$SCRIPT_DIR/fun-facts-splashscreens.sh" --create-fun-fact "$SYSTEM" "$ROM_PATH" #> /dev/null


### PR DESCRIPTION
no matter if the previous image is png or jpg.

Also you don't need to check if a file exists to remove it. Just use `rm -f file` and it's enough. ;-)